### PR TITLE
docs: remove a line that does not belong here

### DIFF
--- a/docs/development/security/security_features_list.md
+++ b/docs/development/security/security_features_list.md
@@ -10,7 +10,6 @@
 - Build signature is checked on-board.
 - Self-destruction can be initiated on Kampela only locally, no api for remote one or one through companion device.
 - Self-destruction must be available without the detachable token or any other authorization.
-- We need to make sure that NFC can provide stable and full energization of the circuit. Undefined behavior due to power surges or lack of energy should be ruled out. We might consider using a small energy storage to provide short-term power supply stability.
 
 ## Firmware
 - Kampela stores all derivations created on it.


### PR DESCRIPTION
This, of course, is important, but it is generally covered by device functionality. As usual, the screen seems to be the most power-consuming component.